### PR TITLE
🗑 Remove NewTask action from page layout

### DIFF
--- a/force-app/main/default/layouts/Contact-Field Worker and Survey Client Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Contact-Field Worker and Survey Client Layout.layout-meta.xml
@@ -154,9 +154,6 @@
             <quickActionName>FeedItem.ContentPost</quickActionName>
         </quickActionListItems>
         <quickActionListItems>
-            <quickActionName>NewTask</quickActionName>
-        </quickActionListItems>
-        <quickActionListItems>
             <quickActionName>LogACall</quickActionName>
         </quickActionListItems>
         <quickActionListItems>


### PR DESCRIPTION
# Changes
To resolve `In field: QuickAction - no QuickAction named NewTask found.` error, we remove the action from the page layout.